### PR TITLE
chain update and install

### DIFF
--- a/php-base/Dockerfile.cli
+++ b/php-base/Dockerfile.cli
@@ -2,18 +2,17 @@ FROM php:7.3-cli
 LABEL description="The Grommet PHP CLI Base"
 LABEL maintainer="todd@thegrommet.com"
 
-RUN apt-get update 
-RUN apt-get install -y \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libicu-dev \
-        libpng-dev \
-        libxml2-dev \
-        libxslt-dev \
-        libc-client-dev \
-        libkrb5-dev \
-        libzip-dev \
-        unzip
+RUN apt-get update && apt-get install -y \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libicu-dev \
+    libpng-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libc-client-dev \
+    libkrb5-dev \
+    libzip-dev \
+    unzip
 
 RUN docker-php-ext-install -j$(nproc) bcmath intl json mbstring pdo_mysql soap xml xsl zip && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \

--- a/php-base/Dockerfile.fpm
+++ b/php-base/Dockerfile.fpm
@@ -2,18 +2,17 @@ FROM php:7.3-fpm
 LABEL description="The Grommet PHP FPM Base"
 LABEL maintainer="todd@thegrommet.com"
 
-RUN apt-get update
-RUN apt-get install -y \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libicu-dev \
-        libpng-dev \
-        libxml2-dev \
-        libxslt-dev \
-        libc-client-dev \
-        libkrb5-dev \
-        libzip-dev \
-        unzip
+RUN apt-get update && apt-get install -y \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libicu-dev \
+    libpng-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libc-client-dev \
+    libkrb5-dev \
+    libzip-dev \
+    unzip
 
 RUN docker-php-ext-install -j$(nproc) bcmath intl json mbstring opcache pdo_mysql soap xml xsl zip && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#dockerfile-instructions

> Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail