### PR TITLE
Makefile revisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ push:
 	docker push dailygrommet/php-cli-base:$(TAG)
 	docker push dailygrommet/php-fpm-base:$(TAG)
 	docker push dailygrommet/ci-php:$(TAG)
-	docker push dailygrommet/awscli:$(TAG)
-	docker push dailygrommet/haproxy:$(TAG)
-	docker push dailygrommet/varnish:$(TAG)
+	docker push dailygrommet/awscli:latest
+	docker push dailygrommet/haproxy:latest
+	docker push dailygrommet/varnish:latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,32 @@
-all:
+
+DEFAULT_TAG=7.3
+ifndef TAG
+	TAG=$(DEFAULT_TAG)
+endif
+
+.DEFAULT_GOAL := help
+.PHONY: help all build tag push
+
+help:
+	@echo "Usage: make [options] [target] ..."
+	@echo "Targets:"
+	@echo "    help       Display this help text"
+	@echo "    all        build, tag, and push images"
+	@echo "    build      build all images"
+	@echo "    tag        tag latest images"
+	@echo "    push       push images to docker hub"
+	@echo
+	@echo "Default TAG: $(DEFAULT_TAG)"
+	@echo "Apply a different tag by assigning TAG before command"
+	@echo "Example:"
+	@echo "    TAG=test make tag"
+	@echo
+
+
+all: build tag push
+
+
+build:
 	docker build -f php-base/Dockerfile.cli -t dailygrommet/php-cli-base php-base
 	docker build -f php-base/Dockerfile.fpm -t dailygrommet/php-fpm-base php-base
 	docker build -t dailygrommet/ci-php ci-php

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all: build tag push
 
 
 build:
+	docker build -f php-base/Dockerfile -t dailygrommet/php-fpm-base php-base
 	docker build -f php-base/Dockerfile.cli -t dailygrommet/php-cli-base php-base
-	docker build -f php-base/Dockerfile.fpm -t dailygrommet/php-fpm-base php-base
 	docker build -t dailygrommet/ci-php ci-php
 	docker build -t dailygrommet/awscli aws-cli
 	docker build -t dailygrommet/haproxy haproxy

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "Targets:"
 	@echo "    help       Display this help text"
 	@echo "    all        build, tag, and push images"
-	@echo "    build      build all images"
+	@echo "    build      build images"
 	@echo "    tag        tag latest images"
 	@echo "    push       push images to docker hub"
 	@echo
@@ -30,9 +30,11 @@ build:
 	docker build -f php-base/Dockerfile -t dailygrommet/php-fpm-base php-base
 	docker build -f php-base/Dockerfile.cli -t dailygrommet/php-cli-base php-base
 	docker build -t dailygrommet/ci-php ci-php
+ifndef PHP_ONLY
 	docker build -t dailygrommet/awscli aws-cli
 	docker build -t dailygrommet/haproxy haproxy
 	docker build -t dailygrommet/varnish varnish
+endif
 
 tag:
 	docker tag dailygrommet/php-cli-base:latest dailygrommet/php-cli-base:$(TAG)
@@ -44,6 +46,8 @@ push:
 	docker push dailygrommet/php-cli-base:$(TAG)
 	docker push dailygrommet/php-fpm-base:$(TAG)
 	docker push dailygrommet/ci-php:$(TAG)
+ifndef PHP_ONLY
 #	docker push dailygrommet/awscli:latest
 #	docker push dailygrommet/haproxy:latest
 #	docker push dailygrommet/varnish:latest
+endif

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ push:
 	docker push dailygrommet/php-cli-base:$(TAG)
 	docker push dailygrommet/php-fpm-base:$(TAG)
 	docker push dailygrommet/ci-php:$(TAG)
-	docker push dailygrommet/awscli:latest
-	docker push dailygrommet/haproxy:latest
-	docker push dailygrommet/varnish:latest
+#	docker push dailygrommet/awscli:latest
+#	docker push dailygrommet/haproxy:latest
+#	docker push dailygrommet/varnish:latest

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ tag:
 	docker tag dailygrommet/php-cli-base:latest dailygrommet/php-cli-base:$(TAG)
 	docker tag dailygrommet/php-fpm-base:latest dailygrommet/php-fpm-base:$(TAG)
 	docker tag dailygrommet/ci-php:latest dailygrommet/ci-php:$(TAG)
+	docker rmi dailygrommet/php-cli-base:latest dailygrommet/php-fpm-base:latest dailygrommet/ci-php:latest
 
 push:
 	docker push dailygrommet/php-cli-base:$(TAG)

--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.3-fpm
-LABEL description="The Grommet PHP CLI Base"
+LABEL description="The Grommet PHP FPM Base"
 LABEL maintainer="todd@thegrommet.com"
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \

--- a/php-base/Dockerfile.cli
+++ b/php-base/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM dailygrommet/php-base
+FROM dailygrommet/php-fpm-base
 LABEL description="The Grommet PHP CLI Base"
 LABEL maintainer="todd@thegrommet.com"
 


### PR DESCRIPTION
d6b5c2b default TAG; add "help"; mv all build; new all

- Apply default TAG value
- Add default target help
- Renamed the "all" command to "build"
- New "all" command executes "build tag push" targets
---

e38087c4373c535ee9e7502c50003d2b6206545f correct FROM image

---

aa1886c fix filename; re-order image build order

Because dailygrommet/php-cli-base is FROM dailygrommet/php-fpm-base we
need to make sure dailygrommet/php-fpm-base is already built.

---

0013429 push latest for awscli, haproxy, varnish

These three images do not follow the same tagging convention used as on
the php oriented images. Our deployment pipeline pulls the latest tag
for these.

---


684f5c3 Comment out for now

Reviewing docker hub it seems these images have not been updated in a
very long time. Just want to discuss with the team this observation
before they get potentially updated.